### PR TITLE
Responsive mobile layout, README refresh, and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brett Buskirk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ python3 -m http.server
 ## Tech
 
 Vanilla HTML / CSS / JavaScript with jQuery, a generated SVG board, and a service worker for offline play. Hosted on GitHub Pages.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,23 +1,48 @@
-# Go #
+# Go (圍棋)
 
-This is an attempt to create one of my favorite games, an ancient board game called `Go`.
+A fully playable version of the ancient board game **Go**, built with vanilla HTML, CSS, and JavaScript. Play a friend on the same screen or take on the built-in computer opponent — on desktop or mobile, online or offline.
 
-The goal is for each player to place `stones` on the board and capture more territory than the other player.
+**▶ Play it: https://brett-buskirk.github.io/go/**
 
-* One player uses white stones and the other player uses black.
-* Once played, a stone cannot be moved.
-* Stones can be `captured`, however, if a group of them is surrounded by opposing stones on all orthogonally-adjacent points, as in the image below.
+## About the game
 
-![Go capture](assets/go-capture.png)  
+Go is a territory game for two players, Black and White, on a 13×13 grid. Players take turns placing stones on the intersections; once placed, a stone never moves, but it can be captured.
 
-* In this example, the `black` stones have gained three points of territory and have captured three `white` stones.
-* When a game is over, the territory is counted along with captured stones to determine a winner.
-* There are more rules, but none of them are important here.  
+* A group of connected stones is captured and removed when the opponent fills its last **liberty** (empty adjacent point).
+* When neither player wants to play on, both **pass** and the territory is counted to decide the winner.
 
-## Just the Basics ##
+![Go capture](assets/go-capture.png)
 
-I have built a rough version of `Go`. It can be played with each click on the board laying an alternating stone. The game can be played as is, but I would really like to add some logic.  
+*In this example the Black stones surround three White stones, capturing them and gaining the territory.*
 
-## The Future ##
+## Features
 
-Hopefully I can eventually add some game logic to this project so that it is a fully playable game. In addition, wiring it up to be playable over the internet would also be a fantastic goal to add while I'm at it!
+* **Complete rules engine** — captures, liberties, the suicide rule, and the ko (repetition) rule, plus pass, resign, and game-over detection.
+* **Territory scoring** — when both players pass, the game enters scoring mode: territory is detected automatically, you click any dead stones to remove them, and a live score is shown using area scoring with komi.
+* **Play against the computer** — choose your color and a difficulty:
+  * **Easy** — a fast heuristic bot that captures, defends its groups, and keeps its eyes.
+  * **Hard** — a Monte Carlo Tree Search (MCTS) opponent that plays out thousands of games to pick its move.
+* **Two-player mode** — pass and play on a single device.
+* **Built-in rules guide** — a Rules button explains everything for newcomers.
+* **Modern, responsive design** — a clean board that scales from desktop down to phones.
+* **Installable PWA** — add it to your home screen and play offline.
+
+## How to play
+
+1. Open the game and pick **Two players** or **vs Computer** (and your color/level).
+2. Click an empty intersection to place a stone. Black moves first.
+3. Surround enemy groups to capture them; avoid suicide and illegal ko moves.
+4. When the game winds down, click **Pass** twice to score. Mark any dead stones, read the final score, and start a **New Game**.
+
+## Running locally
+
+No build step or dependencies — it's plain static files. Either open `index.html` directly, or serve the folder over HTTP (recommended, so the service worker and offline support work):
+
+```sh
+python3 -m http.server
+# then visit http://localhost:8000
+```
+
+## Tech
+
+Vanilla HTML / CSS / JavaScript with jQuery, a generated SVG board, and a service worker for offline play. Hosted on GitHub Pages.

--- a/css/main.css
+++ b/css/main.css
@@ -9,6 +9,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  overflow-x: hidden;
   padding: 64px 16px 48px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   color: #e8eaed;
@@ -50,7 +51,11 @@ h1 {
 }
 
 #controls {
-  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  max-width: calc(100vw - 24px);   /* cap to the viewport so buttons wrap on phones */
   margin-top: 14px;
 }
 
@@ -59,7 +64,6 @@ h1 {
   font-size: 14px;
   font-weight: 500;
   padding: 9px 20px;
-  margin: 0 5px;
   cursor: pointer;
   color: #e8eaed;
   background: rgba(255, 255, 255, 0.07);
@@ -89,6 +93,7 @@ h1 {
 
 #setup {
   text-align: center;
+  max-width: calc(100vw - 24px);   /* keep the options within the viewport */
   margin-top: 14px;
   font-size: 13px;
   color: #aeb6c2;
@@ -314,7 +319,7 @@ h1 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 18px;
+  font-size: calc(var(--stone) * 0.5);
   font-weight: 700;
   color: #d23b3b;
   pointer-events: none;
@@ -327,8 +332,8 @@ h1 {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 12px;
-  height: 12px;
+  width: calc(var(--stone) * 0.3);
+  height: calc(var(--stone) * 0.3);
   border-radius: 50%;
   transform: translate(-50%, -50%);
   pointer-events: none;
@@ -341,4 +346,87 @@ h1 {
 .point.terr-white::after {
   background: #fafafa;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+/* --- mobile / small screens -------------------------------------------- */
+
+@media (max-width: 620px) {
+  body {
+    padding: 14px 10px 32px;
+  }
+
+  /* The title sits inline above the board instead of floating top-left. */
+  h1 {
+    position: static;
+    text-align: center;
+    font-size: 24px;
+    margin-bottom: 4px;
+  }
+
+  #indicator {
+    font-size: 19px;
+  }
+
+  /* Full width so centered text wraps within the viewport instead of
+     shrink-wrapping to one (overflowing) line. */
+  #info,
+  #controls,
+  #setup,
+  #message,
+  #score {
+    width: 100%;
+  }
+
+  #info {
+    margin-top: 10px;
+  }
+
+  #info span {
+    font-size: 12px;
+    padding: 4px 10px;
+    margin: 0 4px;
+  }
+
+  #controls {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  #controls button {
+    font-size: 13px;
+    padding: 8px 14px;
+    margin: 0;
+  }
+
+  #setup {
+    margin-top: 10px;
+    font-size: 12px;
+    line-height: 1.9;
+  }
+
+  #message,
+  #score {
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  #outerborder {
+    margin-top: 14px;
+    border-width: 8px;
+  }
+
+  #rules-overlay {
+    padding: 12px;
+  }
+
+  #rules-modal {
+    padding: 24px 20px 26px;
+  }
+
+  #rules-modal h2 {
+    font-size: 21px;
+  }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -555,21 +555,35 @@ function bestRootMove(root) {
 
 // --- board construction ---------------------------------------------------
 
-const CELL = 44;                       // pixels between adjacent intersections
-const MARGIN = 32;                     // tan border between the outer line and the frame
-const SPAN = (SIZE - 1) * CELL;        // distance across all lines
-const SURFACE = SPAN + MARGIN * 2;     // full board surface size
-const STONE = 40;                      // stone diameter
+const CELL_MAX = 44;                   // largest spacing between intersections (desktop)
 const SVGNS = 'http://www.w3.org/2000/svg';
 // Star points (hoshi) for a 13x13 board: the four 4-4 points plus tengen (center).
 const STARS = [[3, 3], [3, 9], [9, 3], [9, 9], [6, 6]];
 
+let CELL;     // pixels between adjacent intersections (sized to fit the viewport)
+let MARGIN;   // tan border between the outer line and the frame
+let SPAN;     // distance across all lines
+let SURFACE;  // full board surface size
+let STONE;    // stone diameter
 let pointEls = [];                     // pointEls[r][c] -> the intersection's DOM node
 
 // The intersection coordinate (in pixels) for row r / column c.
 const coord = k => MARGIN + k * CELL;
 
+// Size the board to the available space so it fits phones and desktops alike.
+function computeDimensions() {
+  const usableW = Math.min(window.innerWidth, 640) - 32 - 24;  // page padding + wood frame
+  const usableH = window.innerHeight - 240;                    // leave room for the controls
+  const target = Math.max(200, Math.min(usableW, usableH, 592));
+  CELL = Math.max(15, Math.min(CELL_MAX, Math.floor(target / 13.4)));
+  MARGIN = Math.round(CELL * 0.7);
+  STONE = Math.round(CELL * 0.92);
+  SPAN = (SIZE - 1) * CELL;
+  SURFACE = SPAN + MARGIN * 2;
+}
+
 function buildBoard() {
+  computeDimensions();
   const boardEl = document.getElementById('board');
   boardEl.innerHTML = '';
   boardEl.style.width = `${SURFACE}px`;
@@ -598,7 +612,7 @@ function buildBoard() {
     dot.setAttribute('class', 'star');
     dot.setAttribute('cx', coord(j));
     dot.setAttribute('cy', coord(i));
-    dot.setAttribute('r', 3.5);
+    dot.setAttribute('r', Math.max(2, CELL * 0.08));
     svg.appendChild(dot);
   }
   boardEl.appendChild(svg);
@@ -735,6 +749,22 @@ $(function () {
   });
   $(document).on('keydown', evt => {
     if (evt.key === 'Escape') closeRules();
+  });
+
+  // Re-fit the board when the viewport changes (rotation, resize) without
+  // disturbing the game — the board model is preserved, only the DOM is redrawn.
+  let resizeTimer;
+  $(window).on('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      const before = CELL;
+      computeDimensions();
+      if (CELL !== before) {
+        buildBoard();
+        if (scoring) renderScoring(); else render();
+        updateStatus();
+      }
+    }, 150);
   });
 
   newGame();


### PR DESCRIPTION
Final polish before release.

## Mobile
- Board sizes itself to the viewport and rebuilds on resize/rotation; star points, stones, and scoring markers scale with the cell size.
- Controls and setup rows wrap within the viewport (flex-wrap + viewport-capped width); small-screen media query and no horizontal overflow.

## Docs & license
- README rewritten for the finished game (features, how to play, live Pages link, local-run notes); dropped the old online-multiplayer goal.
- Added an MIT LICENSE and referenced it from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)